### PR TITLE
Pass animated value to children

### DIFF
--- a/src/react-scroll-horizontal.js
+++ b/src/react-scroll-horizontal.js
@@ -160,7 +160,7 @@ export default class HorizontalScroll extends Component {
 
               return (
                 <div style={ scrollingElementStyles }>
-                  { this.props.children }
+                  { this.props.children(z) }
                 </div>
               )
             } }
@@ -176,6 +176,7 @@ HorizontalScroll.proptypes = {
   config: PropTypes.object,
   style: PropTypes.object,
   className: PropTypes.string,
+  children: PropTypes.func.isRequired,
 }
 
 HorizontalScroll.defaultProps = {


### PR DESCRIPTION
I think it’d be useful to pass the animated value to children so consumers can add their own animations in addition to what React Scroll Horizontal provides. I’m using the same FAAC technique React Motion uses so children become a `function`.