### PR TITLE
Add animValues prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Props
 * `style`          - Pass a style object through to parent div
 * `config`         - Passes a spring config object to React Motion
 * `className`      - Classnames to pass into the component
-
+* `animValues`     - Emulate scroll by passing a delta value
 
 Gotchas
 

--- a/src/index.js
+++ b/src/index.js
@@ -31,7 +31,16 @@ export default class ScrollHorizontal extends Component {
     }
   }
 
-  componentDidUpdate = () => this.calculate()
+  componentDidUpdate = (prevProps) => {
+    if (prevProps.animValues !== this.props.animValues) {
+      let currentAnimValues = this.state.animValues
+      this.setState({
+        animValues: currentAnimValues + this.props.animValues
+      }, this.calculate())
+    } else {
+      this.calculate()
+    }
+  }
 
   onScrollStart(e) {
     e.preventDefault()
@@ -65,7 +74,8 @@ export default class ScrollHorizontal extends Component {
       // Ensure component has been loaded
       this.calculate.timer !== void 0 &&
       this.props.children === nextProps.children &&
-      this.state.animValues === nextState.animValues
+      this.state.animValues === nextState.animValues &&
+      this.props.animValues === nextProps.animValues
     ) {
       return false
     }

--- a/src/index.js
+++ b/src/index.js
@@ -180,7 +180,8 @@ ScrollHorizontal.propTypes = {
   config: PropTypes.object,
   style: PropTypes.object,
   className: PropTypes.string,
-  children: PropTypes.array.isRequired
+  children: PropTypes.array.isRequired,
+  animValues: PropTypes.number
 }
 
 ScrollHorizontal.defaultProps = {
@@ -188,5 +189,6 @@ ScrollHorizontal.defaultProps = {
   pageLock: false,
   config: null,
   style: { width: `100%`, height: `100%` },
-  className: null
+  className: null,
+  animValues: null
 }


### PR DESCRIPTION
This pr will introduce a way to programmatically emulate scrolling by passing down the prop animValues.

### Main usecase: react-draggable integration
My main reason for this change is so that one could integrate react-draggable with this project. 
The proccess for this is discussed in issue #35. 

*Thanks to @zachgibson for giving me the idea for this pr. (#28) Altough the description was not detailed and no PR was proposed* 😏 

### Alternative usecases
- Slowly scrolling / animating when user is not interacting with the component.
- Reseting scroll on a data change
- Scrolling insanly fast because why not

### Potential improvments
I think the name animValues is not descriptive enough for the prop, so I would propose changing it to scrollDelta or something. What do you recon? 
Maybe changing just the prop name? 

I don't think having a different prop name and state name is the best approch but if you don't want to change animValues internally then maybe it is the best? idk