### PR TITLE
onScroll, onReachStart, onReachEnd callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ npm i react-scroll-horizontal
     config        = {{ stiffness: int, damping: int }}
     className     = { string }
     animValues    = { int }
+    onScroll      = { func(int) }
+    onReachStart  = { func }
+    onReachEnd    = { func }
     >
      { children }
   </HorizontalScroll>
@@ -47,6 +50,9 @@ Props
 * `config`         - Passes a spring config object to React Motion
 * `className`      - Classnames to pass into the component
 * `animValues`     - Emulate scroll by passing a delta value
+* `onScroll`       - Callback for scroll event
+* `onReachStart`   - Function to be called when scroll reaches start
+* `onReachEnd`     - Function to be called when scroll reaches end
 
 Gotchas
 

--- a/src/index.js
+++ b/src/index.js
@@ -32,10 +32,9 @@ export default class ScrollHorizontal extends Component {
   }
 
   componentDidUpdate = (prevProps) => {
-    if (prevProps.animValues !== this.props.animValues) {
-      let currentAnimValues = this.state.animValues
+    if (this.props.animValues !== null && prevProps.animValues !== this.props.animValues) {
       this.setState({
-        animValues: currentAnimValues + this.props.animValues
+        animValues: this.props.animValues
       }, this.calculate())
     } else {
       this.calculate()
@@ -58,10 +57,16 @@ export default class ScrollHorizontal extends Component {
       return
     }
 
+    var newAnimationValueFinal = this.props.reverseScroll
+      ? newAnimationValueNegative
+      : newAnimationValue
+
     var scrolling = () => {
-      this.props.reverseScroll
-        ? this.setState({ animValues: newAnimationValueNegative })
-        : this.setState({ animValues: newAnimationValue })
+      this.setState({ animValues: newAnimationValueFinal })
+    }
+
+    if (this.props.onScroll) {
+      this.props.onScroll(newAnimationValueFinal)
     }
 
     // Begin Scrolling Animation
@@ -111,15 +116,14 @@ export default class ScrollHorizontal extends Component {
 
       // Get the new animation values
       var curr = this.state.animValues
-
       // Establish the bounds. We do this every time b/c it might change.
       var bounds = -(max - win)
 
       // Logic to hold everything in place
-      if (curr >= 1) {
+      if (curr >= 0) {
         this.resetMin()
       } else if (curr <= bounds) {
-        var x = bounds + 1
+        var x = bounds
         this.resetMax(x)
       }
     })
@@ -127,10 +131,18 @@ export default class ScrollHorizontal extends Component {
 
   resetMin() {
     this.setState({ animValues: 0 })
+
+    if (this.props.onReachStart) {
+      this.props.onReachStart()
+    }
   }
 
   resetMax(x) {
-    this.setState({ animValues: x })
+    this.setState({animValues: x})
+
+    if (this.props.onReachEnd) {
+      this.props.onReachEnd()
+    }
   }
 
   render() {
@@ -181,7 +193,10 @@ ScrollHorizontal.propTypes = {
   style: PropTypes.object,
   className: PropTypes.string,
   children: PropTypes.array.isRequired,
-  animValues: PropTypes.number
+  animValues: PropTypes.number,
+  onScroll: PropTypes.func,
+  onReachStart: PropTypes.func,
+  onReachEnd: PropTypes.func
 }
 
 ScrollHorizontal.defaultProps = {

--- a/src/index.js
+++ b/src/index.js
@@ -57,16 +57,10 @@ export default class ScrollHorizontal extends Component {
       return
     }
 
-    var newAnimationValueFinal = this.props.reverseScroll
-      ? newAnimationValueNegative
-      : newAnimationValue
-
     var scrolling = () => {
-      this.setState({ animValues: newAnimationValueFinal })
-    }
-
-    if (this.props.onScroll) {
-      this.props.onScroll(newAnimationValueFinal)
+      this.props.reverseScroll
+        ? this.setState({ animValues: newAnimationValueNegative })
+        : this.setState({ animValues: newAnimationValue })
     }
 
     // Begin Scrolling Animation
@@ -116,6 +110,10 @@ export default class ScrollHorizontal extends Component {
 
       // Get the new animation values
       var curr = this.state.animValues
+
+      if (this.props.onScroll) {
+        this.props.onScroll(curr)
+      }
       // Establish the bounds. We do this every time b/c it might change.
       var bounds = -(max - win)
 


### PR DESCRIPTION
I found _react-scroll-horizontal_ very useful, but in my use case I needed some more control over the component and I wanted to run callbacks on reaching the scrolling area boundaries. I've made a few changes, that maybe you find reasonable enough to merge them to the repository.

This PR introduces `onScroll`, `onReachStart` and `onReachEnd` callbacks and changes also a little bit of existing logic, as described below.

1.
```
if (prevProps.animValues !== this.props.animValues) {	 
    let currentAnimValues = this.state.animValues	
    this.setState({	  
        animValues: currentAnimValues + this.props.animValues	       
    }, this.calculate())	  
}
``` 
Controlling scroll position by a relative value seems a bit limited to me. My feeling is that if a component can be controlled from the parent level, it should be fully controlled by an absolute value (and return current position to `onScroll` callback). It gives possibility to set scroll position exactly where you want to (at the start, at the end, to some element). So I've changed this `setState` to `animValues: this.props.animValues`.
However, I'm aware that this is kind of a "breaking change" and that scrolling by relative value may be good for some use cases. I'm thinking about keeping these two ways of controlling the scroll position maybe?

2.
```
if (curr >= 1) {	  
    this.resetMin()	    
} else if (curr <= bounds) {	   
    var x = bounds + 1	     
    this.resetMax(x)	 
}
```
I'm not sure what was the purpose of `1` and `+1`, but I discovered that if scroll position is controlled by the `animValues` property and you set limit values (`0`, max), newly introduced `onReachStart` and `onReachEnd` (placed in `resetMin` and `resetMax`) wouldn't be called. I haven't noticed any issues after changing this part, but if I did some wrong here and should call these callbacks somewhere else, then please let me know.