### PR TITLE
Chrome passive event disables preventDefault fixed

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,8 @@ export default class ScrollHorizontal extends Component {
       const orig = document.firstElementChild.className
       document.firstElementChild.className = orig + (orig ? ' ' : '') + 'locked__'
     }
+
+    DOM.findDOMNode(this.hScrollParent).addEventListener('wheel', this.onScrollStart, { passive: false })
   }
 
   componentWillUnmount() {
@@ -29,6 +31,8 @@ export default class ScrollHorizontal extends Component {
         ''
       )
     }
+
+    DOM.findDOMNode(this.hScrollParent).removeEventListener('wheel', this.onScrollStart)
   }
 
   componentDidUpdate = (prevProps) => {
@@ -149,7 +153,6 @@ export default class ScrollHorizontal extends Component {
 
     return (
       <div
-        onWheel={this.onScrollStart}
         ref={r => {
           this.hScrollParent = r
         }}


### PR DESCRIPTION
Since the chrome intervention from February 2019 (Making wheel scrolling fast by default), the mouse wheel event is registered by default as a passive event and passive events ignore the preventDefault method.
https://developers.google.com/web/updates/2019/02/scrolling-intervention

This is also an open issue in this repository:
https://github.com/hew/react-scroll-horizontal/issues/82

The fix - registering the event in componentDidMount with {passive: false}